### PR TITLE
Usuń pole „Odczucie” z podglądu sesji i podbij wersję do 5.0.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aplikacja Treningowa (Smart Rehab PWA) v5.0.55
+# Aplikacja Treningowa (Smart Rehab PWA) v5.0.56
 
 Zaawansowana aplikacja PWA (Progressive Web App) łącząca inteligentny trening siłowy z nowoczesną rehabilitacją. System wykorzystuje architekturę Serverless (Netlify Functions + Neon DB) oraz silnik **"Adaptive Calendar Engine (ACE)"**, który zamiast sztywnych planów tygodniowych generuje dynamiczne, "kroczące" okno treningowe dopasowane do realnego kalendarza użytkownika.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aplikacja-treningowa",
-  "version": "5.0.55",
+  "version": "5.0.56",
   "description": "Aplikacja do śledzenia planów treningowych.",
   "main": "app.js",
   "private": true,

--- a/ui/templates.js
+++ b/ui/templates.js
@@ -559,8 +559,6 @@ export function generateSessionCardHTML(session) {
     }
     const mins = Math.floor(durationNetto / 60);
 
-    const fb = formatFeedback(session);
-
     let sessionLoad = 0;
     if (session.sessionLog) sessionLoad = calculateSystemLoad(session.sessionLog, true);
     if (sessionLoad === 0) sessionLoad = 50;
@@ -617,16 +615,11 @@ export function generateSessionCardHTML(session) {
                     ${statusBadge}
                 </div>
 
-                <div style="display:grid; grid-template-columns: 1fr 1fr 1fr; gap:6px; margin-top:10px;">
+                <div style="display:grid; grid-template-columns: 1fr 1fr; gap:6px; margin-top:10px;">
                     <div style="${gridItemStyle}">
                         <div style="font-size:1rem; margin-bottom:2px;">⏱️</div>
                         <div style="font-weight:800; font-size:0.9rem; color:#333;">${mins}m</div>
                         <div style="font-size:0.6rem; color:#888; text-transform:uppercase;">Czas Netto</div>
-                    </div>
-                    <div style="${gridItemStyle} background:${fb.bg};">
-                        <div style="font-size:1rem; margin-bottom:2px;">${fb.icon}</div>
-                        <div style="font-weight:800; font-size:0.9rem; color:#333;">${fb.label}</div>
-                        <div style="font-size:0.6rem; color:#888; text-transform:uppercase;">Odczucie</div>
                     </div>
                     <div style="${gridItemStyle}">
                         <div style="font-size:1rem; margin-bottom:2px;">📊</div>


### PR DESCRIPTION
### Motivation
- Usuń historyczny/niepotrzebny kafelek „Odczucie” z widoku podglądu/ historii sesji, aby wyczyścić UI i nie wyświetlać nieobsługiwanego pola feedback.
- Zgodnie z wymaganiem zawsze podbić wersję aplikacji i utrzymać README aktualnym, stąd bump wersji i aktualizacja nagłówka README.
- Nie użyto żadnego z dostępnych skills z `AGENTS.md`, ponieważ zmiana to prosta modyfikacja frontendowego szablonu i metadanych wersji.

### Description
- Usunięto użycie `formatFeedback(session)` oraz cały kafelek „Odczucie” z `generateSessionCardHTML` w `ui/templates.js` i dostosowano układ metryk z 3 kolumn na 2 kolumny (wyświetlane: `Czas Netto`, `Obciążenie`).
- Zmieniono `grid-template-columns` z `1fr 1fr 1fr` na `1fr 1fr` w sekcji karty sesji w `ui/templates.js`.
- Podbito wersję aplikacji w `package.json` z `5.0.55` do `5.0.56`.
- Zaktualizowano nagłówek wersji w `README.md` do `v5.0.56`.

### Testing
- Uruchomiono testy jednostkowe/integrajne za pomocą `npm test` i wszystkie testy zakończyły się pomyślnie (`142` testy przeszły).
- Uruchomiono linter poprzez `npm run lint` i sprawdzenie składni JS smoke za pomocą `npm run lint:js:syntax` zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adf2af42188327a847a286c1e8683d)